### PR TITLE
feat: add "The Fun Box" popover with interactive toggles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^16.2.1",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -198,6 +199,8 @@
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^16.2.1",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.8",
         "axios": "^1.10.0",
@@ -204,7 +205,13 @@
 
     "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
 
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
 
     "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
 
@@ -338,6 +345,8 @@
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
@@ -419,6 +428,8 @@
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -523,6 +534,8 @@
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
@@ -838,7 +851,13 @@
 
     "react-icons": ["react-icons@5.5.0", "", { "peerDependencies": { "react": "*" } }, "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
     "react-snowfall": ["react-snowfall@2.4.0", "", { "dependencies": { "react-fast-compare": "^3.2.2" }, "peerDependencies": { "react": "^16.8 || 17.x || 18.x || 19.x", "react-dom": "^16.8 || 17.x || 18.x || 19.x" } }, "sha512-KAPMiGnxt11PEgC2pTVrTQsvk5jt1kLUtG+ZamiKLphTZ7GiYT1Aa5kX6jp4jKWq1kqJHchnGT9CDm4g86A5Gg=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-syntax-highlighter": ["react-syntax-highlighter@15.6.1", "", { "dependencies": { "@babel/runtime": "^7.3.1", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.27.0", "refractor": "^3.6.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg=="],
 
@@ -997,6 +1016,10 @@
     "update-browserslist-db": ["update-browserslist-db@1.1.4", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A=="],
 
     "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
+
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "tui": "bun tui-portfolio/src/index.tsx"
   },
   "dependencies": {
+    "@baghel/goey-toast": "^0.3.3",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^16.2.1",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",
     "axios": "^1.10.0",
@@ -23,9 +25,8 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
-    "gray-matter": "^4.0.3",
     "framer-motion": "^12.0.0",
-    "@baghel/goey-toast": "^0.3.3",
+    "gray-matter": "^4.0.3",
     "lenis": "^1.3.22",
     "lucide-react": "^0.539.0",
     "motion": "^12.26.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^16.2.1",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,9 @@ import StructuredData from "@/components/StructuredData";
 import VisitorBadge from "@/components/analytics/VisitorBadge";
 import { FaviconAnimator } from "@/components/FaviconAnimator";
 import GooeyToasterClient from "@/components/GooeyToasterClient";
+import { Suspense } from "react";
 import SmoothScroll from "@/components/SmoothScroll";
+import FunBox from "@/components/FunBox";
 
 const chromate = localFont({
   src: "./Chromate-Regular.ttf",
@@ -150,6 +152,9 @@ export default function RootLayout({
           <PostHogProvider>
             <GooeyToasterClient />
             {children}
+            <Suspense>
+              <FunBox />
+            </Suspense>
             <VisitorBadge />
           </PostHogProvider>
         </SmoothScroll>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ import StructuredData from "@/components/StructuredData";
 import VisitorBadge from "@/components/analytics/VisitorBadge";
 import { FaviconAnimator } from "@/components/FaviconAnimator";
 import GooeyToasterClient from "@/components/GooeyToasterClient";
-// import SmoothScroll from "@/components/SmoothScroll";
+import SmoothScroll from "@/components/SmoothScroll";
 
 const chromate = localFont({
   src: "./Chromate-Regular.ttf",
@@ -146,13 +146,13 @@ export default function RootLayout({
       </head>
       <body className={`${inter.variable} ${chromate.variable} font-sans`}>
         <FaviconAnimator />
-        {/* <SmoothScroll> */}
+        <SmoothScroll>
           <PostHogProvider>
             <GooeyToasterClient />
             {children}
             <VisitorBadge />
           </PostHogProvider>
-        {/* </SmoothScroll> */}
+        </SmoothScroll>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,9 @@ export default async function Home({
       >
         <HeroImage />
         <EasterEggLogs />
-        <WorkExperience />
+        <Suspense>
+          <WorkExperience />
+        </Suspense>
         <FloatingShape
           shapeUrl="/shapes/shape-81.svg"
           directionClass="left-[-20px] bottom-[-20px]"

--- a/src/components/FunBox.tsx
+++ b/src/components/FunBox.tsx
@@ -93,6 +93,7 @@ export default function FunBox() {
 
   const isBW = searchParams.get('bw') === 'true';
   const isFastSpin = searchParams.get('spin') === 'faster';
+  const isSnowOn = searchParams.get('snow') !== 'off';
 
   function toggleParam(key: string, value: string) {
     const params = new URLSearchParams(searchParams.toString());
@@ -100,6 +101,17 @@ export default function FunBox() {
       params.delete(key);
     } else {
       params.set(key, value);
+    }
+    const query = params.toString();
+    router.push(query ? `?${query}` : '/', { scroll: false });
+  }
+
+  function toggleSnow() {
+    const params = new URLSearchParams(searchParams.toString());
+    if (params.get('snow') === 'off') {
+      params.delete('snow');
+    } else {
+      params.set('snow', 'off');
     }
     const query = params.toString();
     router.push(query ? `?${query}` : '/', { scroll: false });
@@ -176,6 +188,11 @@ export default function FunBox() {
                   label="Fast Spin"
                   isOn={isFastSpin}
                   onToggle={() => toggleParam('spin', 'faster')}
+                />
+                <Toggle
+                  label="Snowfall"
+                  isOn={isSnowOn}
+                  onToggle={toggleSnow}
                 />
               </div>
             </div>

--- a/src/components/FunBox.tsx
+++ b/src/components/FunBox.tsx
@@ -1,18 +1,18 @@
-'use client';
+"use client";
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { TbAdjustmentsCog } from 'react-icons/tb';
-import { ChevronDown } from 'lucide-react';
+import { useRouter, useSearchParams } from "next/navigation";
+import { TbAdjustmentsCog } from "react-icons/tb";
+import { ChevronDown } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from '@/components/ui/popover';
+} from "@/components/ui/popover";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+} from "@/components/ui/collapsible";
 
 interface EasterEgg {
   emoji: string;
@@ -23,35 +23,35 @@ interface EasterEgg {
 
 const easterEggs: EasterEgg[] = [
   {
-    emoji: '🌀',
-    name: 'Fast Spin',
-    description: 'The background blob goes brrrrr',
-    link: '/?spin=faster',
+    emoji: "🌀",
+    name: "Fast Spin",
+    description: "The background blob goes brrrrr",
+    link: "/?spin=faster",
   },
   {
-    emoji: '🖤',
-    name: 'B&W Mode',
-    description: 'Everything turns grayscale',
-    link: '/?bw=true',
+    emoji: "🖤",
+    name: "B&W Mode",
+    description: "Everything turns grayscale",
+    link: "/?bw=true",
   },
   {
-    emoji: '💻',
-    name: 'Console Secrets',
-    description: 'Open DevTools & type showSecrets()',
+    emoji: "💻",
+    name: "Console Secrets",
+    description: "Open DevTools & type showSecrets()",
   },
   {
-    emoji: '👀',
-    name: 'Spinning Favicon',
-    description: 'Look at your browser tab icon!',
+    emoji: "👀",
+    name: "Spinning Favicon",
+    description: "Look at your browser tab icon!",
   },
   {
-    emoji: '✨',
-    name: 'Grid Distortion',
-    description: 'Hover over the hero image',
+    emoji: "✨",
+    name: "Grid Distortion",
+    description: "Hover over the hero image",
   },
   {
-    emoji: '❄️',
-    name: 'Snowfall',
+    emoji: "❄️",
+    name: "Snowfall",
     description: "It's snowing in work experience",
   },
 ];
@@ -74,12 +74,12 @@ function Toggle({
       <span className="text-sm font-semibold text-slate-900">{label}</span>
       <div
         className={`relative h-6 w-11 rounded-full border-2 border-slate-900 transition-colors duration-200 ${
-          isOn ? 'bg-lime-400' : 'bg-slate-200'
+          isOn ? "bg-lime-400" : "bg-slate-200"
         }`}
       >
         <div
           className={`absolute top-0.5 h-4 w-4 rounded-full border-2 border-slate-900 bg-white transition-transform duration-200 ${
-            isOn ? 'translate-x-5' : 'translate-x-0.5'
+            isOn ? "translate-x-5" : "translate-x-0.5"
           }`}
         />
       </div>
@@ -91,9 +91,9 @@ export default function FunBox() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const isBW = searchParams.get('bw') === 'true';
-  const isFastSpin = searchParams.get('spin') === 'faster';
-  const isSnowOn = searchParams.get('snow') !== 'off';
+  const isBW = searchParams.get("bw") === "true";
+  const isFastSpin = searchParams.get("spin") === "faster";
+  const isSnowOn = searchParams.get("snow") !== "off";
 
   function toggleParam(key: string, value: string) {
     const params = new URLSearchParams(searchParams.toString());
@@ -103,18 +103,18 @@ export default function FunBox() {
       params.set(key, value);
     }
     const query = params.toString();
-    router.push(query ? `?${query}` : '/', { scroll: false });
+    router.push(query ? `?${query}` : "/", { scroll: false });
   }
 
   function toggleSnow() {
     const params = new URLSearchParams(searchParams.toString());
-    if (params.get('snow') === 'off') {
-      params.delete('snow');
+    if (params.get("snow") === "off") {
+      params.delete("snow");
     } else {
-      params.set('snow', 'off');
+      params.set("snow", "off");
     }
     const query = params.toString();
-    router.push(query ? `?${query}` : '/', { scroll: false });
+    router.push(query ? `?${query}` : "/", { scroll: false });
   }
 
   return (
@@ -136,7 +136,8 @@ export default function FunBox() {
           className="w-80 rounded-[20px] border-[3px] border-slate-900 bg-white p-4 shadow-[4px_4px_0px_0px_#1e293b]"
         >
           <div className="space-y-4">
-            <Collapsible defaultOpen={false}>
+            {/* Easter Eggs Collapsible */}
+            {/*<Collapsible defaultOpen={false}>
               <CollapsibleTrigger className="group flex w-full items-center justify-between mb-2">
                 <h4 className="text-xs font-bold uppercase tracking-wider text-slate-500">
                   Easter Eggs
@@ -172,7 +173,7 @@ export default function FunBox() {
                   ))}
                 </div>
               </CollapsibleContent>
-            </Collapsible>
+            </Collapsible>*/}
 
             <div>
               <h4 className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-500">
@@ -182,12 +183,12 @@ export default function FunBox() {
                 <Toggle
                   label="B&W Mode"
                   isOn={isBW}
-                  onToggle={() => toggleParam('bw', 'true')}
+                  onToggle={() => toggleParam("bw", "true")}
                 />
                 <Toggle
                   label="Fast Spin"
                   isOn={isFastSpin}
-                  onToggle={() => toggleParam('spin', 'faster')}
+                  onToggle={() => toggleParam("spin", "faster")}
                 />
                 <Toggle
                   label="Snowfall"

--- a/src/components/FunBox.tsx
+++ b/src/components/FunBox.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { TbAdjustmentsCog } from 'react-icons/tb';
+import { ChevronDown } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+
+interface EasterEgg {
+  emoji: string;
+  name: string;
+  description: string;
+  link?: string;
+}
+
+const easterEggs: EasterEgg[] = [
+  {
+    emoji: '🌀',
+    name: 'Fast Spin',
+    description: 'The background blob goes brrrrr',
+    link: '/?spin=faster',
+  },
+  {
+    emoji: '🖤',
+    name: 'B&W Mode',
+    description: 'Everything turns grayscale',
+    link: '/?bw=true',
+  },
+  {
+    emoji: '💻',
+    name: 'Console Secrets',
+    description: 'Open DevTools & type showSecrets()',
+  },
+  {
+    emoji: '👀',
+    name: 'Spinning Favicon',
+    description: 'Look at your browser tab icon!',
+  },
+  {
+    emoji: '✨',
+    name: 'Grid Distortion',
+    description: 'Hover over the hero image',
+  },
+  {
+    emoji: '❄️',
+    name: 'Snowfall',
+    description: "It's snowing in work experience",
+  },
+];
+
+function Toggle({
+  label,
+  isOn,
+  onToggle,
+}: {
+  label: string;
+  isOn: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex w-full items-center justify-between rounded-xl border-2 border-slate-900 bg-white px-3.5 py-2.5 shadow-[3px_3px_0px_0px_#84cc16] transition-all duration-200 hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none"
+    >
+      <span className="text-sm font-semibold text-slate-900">{label}</span>
+      <div
+        className={`relative h-6 w-11 rounded-full border-2 border-slate-900 transition-colors duration-200 ${
+          isOn ? 'bg-lime-400' : 'bg-slate-200'
+        }`}
+      >
+        <div
+          className={`absolute top-0.5 h-4 w-4 rounded-full border-2 border-slate-900 bg-white transition-transform duration-200 ${
+            isOn ? 'translate-x-5' : 'translate-x-0.5'
+          }`}
+        />
+      </div>
+    </button>
+  );
+}
+
+export default function FunBox() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const isBW = searchParams.get('bw') === 'true';
+  const isFastSpin = searchParams.get('spin') === 'faster';
+
+  function toggleParam(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (params.get(key) === value) {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    const query = params.toString();
+    router.push(query ? `?${query}` : '/', { scroll: false });
+  }
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 hidden lg:block">
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Open The Fun Box"
+            className="rounded-full border-[3px] border-slate-900 bg-white p-2.5 shadow-[3px_3px_0px_0px_#84cc16] transition-all duration-200 hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none"
+          >
+            <TbAdjustmentsCog className="text-2xl text-slate-900" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="end"
+          sideOffset={12}
+          className="w-80 rounded-[20px] border-[3px] border-slate-900 bg-white p-4 shadow-[4px_4px_0px_0px_#1e293b]"
+        >
+          <div className="space-y-4">
+            <Collapsible defaultOpen={false}>
+              <CollapsibleTrigger className="group flex w-full items-center justify-between mb-2">
+                <h4 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+                  Easter Eggs
+                </h4>
+                <ChevronDown className="h-4 w-4 text-slate-500 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="space-y-1.5">
+                  {easterEggs.map((egg) => (
+                    <div
+                      key={egg.name}
+                      className="flex items-start gap-2.5 rounded-xl border border-slate-200 bg-slate-50 p-2.5"
+                    >
+                      <span className="mt-px text-base">{egg.emoji}</span>
+                      <div className="min-w-0 flex-1">
+                        {egg.link ? (
+                          <a
+                            href={egg.link}
+                            className="text-sm font-semibold text-slate-900 underline decoration-dashed underline-offset-2 hover:text-lime-600"
+                          >
+                            {egg.name}
+                          </a>
+                        ) : (
+                          <p className="text-sm font-semibold text-slate-900">
+                            {egg.name}
+                          </p>
+                        )}
+                        <p className="text-xs text-slate-500">
+                          {egg.description}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+
+            <div>
+              <h4 className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-500">
+                Quick Toggles
+              </h4>
+              <div className="space-y-2">
+                <Toggle
+                  label="B&W Mode"
+                  isOn={isBW}
+                  onToggle={() => toggleParam('bw', 'true')}
+                />
+                <Toggle
+                  label="Fast Spin"
+                  isOn={isFastSpin}
+                  onToggle={() => toggleParam('spin', 'faster')}
+                />
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { MdWork as WorkIcon } from 'react-icons/md';
 import { BsBuildingsFill as CompanyIcon } from 'react-icons/bs';
 import { FaLocationDot as LocationIcon } from 'react-icons/fa6';
@@ -8,9 +9,12 @@ import Snowfall from 'react-snowfall';
 import ScrollReveal from '@/components/ScrollReveal';
 
 export default function WorkExperience() {
+  const searchParams = useSearchParams();
+  const snowEnabled = searchParams.get('snow') !== 'off';
+
   return (
     <>
-      <Snowfall />
+      {snowEnabled && <Snowfall />}
       <section
         id="work"
         className="relative z-10 mt-32 2xl:mt-52 p-6 text-slate-900"

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }


### PR DESCRIPTION
## Summary

- Add a new "The Fun Box" popover component (`FunBox.tsx`) fixed to the bottom-right corner, visible only on desktop (`lg:` breakpoint and above)
- The popover is triggered by a `TbAdjustmentsCog` icon and contains quick toggles for B&W mode, fast spin, and snowfall
- Includes an easter egg directory (collapsible, currently commented out for future use)
- Snowfall in `WorkExperience` is now conditional and can be toggled on/off via URL param

## Changes

### New files
- `src/components/FunBox.tsx` — Popover component with toggle switches for theme/experience controls
- `src/components/ui/popover.tsx` — shadcn Popover primitive (Radix)
- `src/components/ui/collapsible.tsx` — shadcn Collapsible primitive (Radix)

### Modified files
- `src/components/WorkExperience.tsx` — Snowfall now reads `?snow=off` from URL to conditionally hide
- `src/app/layout.tsx` — Import and render `<FunBox />` wrapped in `<Suspense>`
- `src/app/page.tsx` — Wrap `<WorkExperience />` in `<Suspense>` (now uses `useSearchParams`)
- `package.json` — Added `@radix-ui/react-popover` and `@radix-ui/react-collapsible`

## Toggles available

| Toggle | Default | URL param |
|---|---|---|
| B&W Mode | Off | `?bw=true` |
| Fast Spin | Off | `?spin=faster` |
| Snowfall | On | `?snow=off` to disable |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Fun Box" settings panel with toggles for visual effects (black & white mode, spinning animation, and snow effect).
  * Snow effect can now be toggled on/off via query parameters.

* **Refactor**
  * Integrated suspense boundaries for improved performance and loading state management.

* **Chores**
  * Reorganized dependency declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->